### PR TITLE
pass error when rejecting promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ async function promise(cmd) {
 		exec(cmd, (error, stdout, stderr) => {
 			if (error) {
 				handleError(error);
-				reject();
+				reject(error);
 			}
 			resolve();
 		});


### PR DESCRIPTION
Now error can be used in catch block that handles the error